### PR TITLE
Attempt to fix www.k3s.io

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@
 module.exports = {
   title: 'K3s',
   tagline: '',
-  url: 'https://k3s-io.github.io',
+  url: 'https://www.k3s.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -29,7 +29,7 @@ module.exports = {
       },
       items: [
         {
-          to:  'https://k3s-io.github.io/docs',
+          to:  'https://docs.k3s.io',
           position: 'right',
           label: 'Docs',
           className: 'navbar__docs',


### PR DESCRIPTION
Change the base website to be www.k3s.io, not just k3s.io
Signed-off-by: Derek Nola <derek.nola@suse.com>