### PR TITLE
Ensure CNAME gets added to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
+          cname: k3s.io
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
Every time we update the site, the CNAME file on `gh-pages` gets clobbered. This prevents that. 
Signed-off-by: Derek Nola <derek.nola@suse.com>