### PR TITLE
fix: mobile screen layout white space on the right side

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -114,3 +114,16 @@ hr {
   padding: 0 var(--ifm-pre-padding);
 }
 
+/**
+* There's -32px margin right is getting added to footer; probably upstream theme
+* So, this is just workaround to fix layout issue on mobile screens
+*/
+footer .container.container-fluid {
+  margin-right: 0 !important;
+  margin-left: 0 !important;
+  padding: 0 !important;
+}
+
+footer .footer__copyright{
+    padding: 0 16px;
+}


### PR DESCRIPTION
Before

![k3s io_ (1)](https://github.com/user-attachments/assets/02f6dc87-1c2a-4fcb-ad51-6fbf48e17021)

After

![localhost_3000_ (1)](https://github.com/user-attachments/assets/4557c916-0ff8-407d-9fc4-ea05b31fe329)
