### PR TITLE
fix: footer content not center

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -113,17 +113,3 @@ hr {
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
-
-/**
-* There's -32px margin right is getting added to footer; probably upstream theme
-* So, this is just workaround to fix layout issue on mobile screens
-*/
-footer .container.container-fluid {
-  margin-right: 0 !important;
-  margin-left: 0 !important;
-  padding: 0 !important;
-}
-
-footer .footer__copyright{
-    padding: 0 16px;
-}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -3,7 +3,7 @@ Below is used for the k3s.io landing page
 ----------------------------------*/
 
 * {
- box-sizing:inherit
+  box-sizing: border-box
 }
 
 .bgPrimary {


### PR DESCRIPTION
The content of footer not centered on PC browser.

<img width="2880" height="250" alt="image" src="https://github.com/user-attachments/assets/9f5d776f-6c47-4234-925e-2b1c51d6f2db" />

After deep research, I found the reason: there a PR #21 fixed white space on mobile which caused the PC issue.

The reason of white space on mobile is the `box-sizing: inherit`, change to `border-box` will fix white space on mobile, and revert #21 is safe to fix PC issue.